### PR TITLE
Import Backend DTO's with openapi-typescript-generator + add abstraction for api and state

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "root": true,
   "ignorePatterns": [
-    "build/**"
+    "build/**",
+    "src/generated/**"
   ],
   "plugins": [
     "prettier",

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,6 +24,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run openapi-generate
+
       - run: npm run lint-check
 
   unit-tests:
@@ -45,6 +47,8 @@ jobs:
             ${{ runner.os }}-node-
 
       - run: npm ci
+
+      - run: npm run openapi-generate
 
       - run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /node_modules
 /.pnp
 .pnp.js
+/src/generated
 
 # testing
 /coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 /build
+/src/generated

--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ Then apply the patches from commits:
 - 728196a (screw-your-neighbor-server-openapi.json: add embedded relations).
 
 Then run again `npm run openapi-generate`
+
+### Architecture
+
+This app uses [MobX](https://github.com/mobxjs/mobx) as state management.  
+The api is provided in [api.ts](src/api/api.ts), but then wrapped with the hook [useApi()](src/hooks/api/useApi.ts)
+to provide global error handling and to display the [ApiErrorSnackBar](src/components/ui/ApiErrorSnackBar.tsx).  
+The error message to show is stored in the [AppStore](src/stores/AppStore.ts) which contains also all other stores.  
+The AppStore is provided via the [useContext()](https://reactjs.org/docs/hooks-reference.html#usecontext)
+hook mechanism in [AppContext](src/AppContext.tsx).
+The [PlayerStore](src/stores/PlayerStore.ts) stores your own player and the list of players in the lobby.
+
+The stores (and the api) should not be used directly in the components,
+but wrapped together with api calls in custom hooks like in [usePlayers()](src/hooks/api/usePlayers.ts).
+
+If you want to show values from the store, don't forget to wrap your component in an observer(), like shown
+in [Lobby](src/components/views/Lobby.tsx).

--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ By group 36 of the course "Software Praktikum"@UZH in FS 22.
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=sopra-fs22-group-36_screw-your-neighbor-react&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=sopra-fs22-group-36_screw-your-neighbor-react)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=sopra-fs22-group-36_screw-your-neighbor-react&metric=coverage)](https://sonarcloud.io/summary/new_code?id=sopra-fs22-group-36_screw-your-neighbor-react)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=sopra-fs22-group-36_screw-your-neighbor-react&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=sopra-fs22-group-36_screw-your-neighbor-react)
+
+## Development
+
+### Generate the classes of the api:
+
+`npm run openapi-generate`
+
+### Update the classes of the api:
+
+Download the screw-your-neighbor-server-openapi.json from the server under the path /v3/api-docs.
+Then apply the patches from commits:
+
+- 728196a (screw-your-neighbor-server-openapi.json: add embedded relations).
+
+Then run again `npm run openapi-generate`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "5.5.1",
         "@mui/material": "5.5.2",
         "axios": "0.26.1",
+        "form-data": "4.0.0",
         "prop-types": "15.8.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -33,6 +34,7 @@
         "eslint": "8.12.0",
         "eslint-plugin-prettier": "4.0.0",
         "lint-staged": "12.3.6",
+        "openapi-typescript-codegen": "0.20.1",
         "prettier": "2.6.0",
         "react-scripts": "5.0.0",
         "typescript": "4.6.2"
@@ -49,6 +51,36 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1995,6 +2027,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@mui/base": {
       "version": "5.0.0-alpha.73",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.73.tgz",
@@ -2007,6 +2045,23 @@
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/icons-material": {
@@ -2015,6 +2070,23 @@
       "integrity": "sha512-40f68p5+Yhq3dCn3QYHqQt5RETPyR3AkDw+fma8PtcjqvZ+d+jF84kFmT6NqwA3he7TlwluEtkyAmPzUE4uPdA==",
       "dependencies": {
         "@babel/runtime": "^7.17.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {
@@ -2034,6 +2106,31 @@
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2",
         "react-transition-group": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/private-theming": {
@@ -2044,6 +2141,22 @@
         "@babel/runtime": "^7.17.2",
         "@mui/utils": "^5.5.3",
         "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/styled-engine": {
@@ -2054,6 +2167,26 @@
         "@babel/runtime": "^7.17.2",
         "@emotion/cache": "^11.7.1",
         "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/system": {
@@ -2069,12 +2202,44 @@
         "clsx": "^1.1.1",
         "csstype": "^3.0.11",
         "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/types": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.3.tgz",
-      "integrity": "sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA=="
+      "integrity": "sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA==",
+      "peerDependencies": {
+        "@types/react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@mui/utils": {
       "version": "5.5.3",
@@ -2086,6 +2251,16 @@
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3373,8 +3548,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -3817,6 +3991,12 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4122,7 +4302,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       }
@@ -4703,8 +4882,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -5956,10 +6134,9 @@
       "dev": true
     },
     "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6173,6 +6350,27 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/harmony-reflect": {
       "version": "1.6.2",
@@ -7492,6 +7690,20 @@
         "xml-name-validator": "^3.0.0"
       }
     },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7514,6 +7726,18 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
+    },
+    "node_modules/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -7958,14 +8182,12 @@
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       }
@@ -8322,6 +8544,30 @@
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
+      }
+    },
+    "node_modules/openapi-typescript-codegen": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.20.1.tgz",
+      "integrity": "sha512-07Fn/es5a3G696tyqkukmgOr/xH3vGnAp32dQO1mb4mSWmIEgtkMtjm+p7htphGhH0jLX1ruPaGfzU+WkdvIGw==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "commander": "^9.0.0",
+        "handlebars": "^4.7.7",
+        "json-schema-ref-parser": "^9.0.9"
+      },
+      "bin": {
+        "openapi": "bin/index.js"
+      }
+    },
+    "node_modules/openapi-typescript-codegen/node_modules/commander": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
+      "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/optionator": {
@@ -11034,6 +11280,19 @@
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
+    "node_modules/uglify-js": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -11543,6 +11802,12 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "node_modules/workbox-background-sync": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.5.1.tgz",
@@ -11982,6 +12247,35 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -13950,6 +14244,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "@mui/base": {
       "version": "5.0.0-alpha.73",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.73.tgz",
@@ -14029,7 +14329,8 @@
     "@mui/types": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.3.tgz",
-      "integrity": "sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA=="
+      "integrity": "sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA==",
+      "requires": {}
     },
     "@mui/utils": {
       "version": "5.5.3",
@@ -15342,8 +15643,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -15792,6 +16092,12 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -16101,7 +16407,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -16694,8 +16999,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -17966,10 +18270,9 @@
       }
     },
     "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -18185,6 +18488,19 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
     },
     "harmony-reflect": {
       "version": "1.6.2",
@@ -19514,6 +19830,19 @@
         "whatwg-url": "^8.5.0",
         "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "jsesc": {
@@ -19538,6 +19867,15 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
+    },
+    "json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+      "dev": true,
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -19990,14 +20328,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -20356,6 +20692,26 @@
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
+      }
+    },
+    "openapi-typescript-codegen": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.20.1.tgz",
+      "integrity": "sha512-07Fn/es5a3G696tyqkukmgOr/xH3vGnAp32dQO1mb4mSWmIEgtkMtjm+p7htphGhH0jLX1ruPaGfzU+WkdvIGw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.3.0",
+        "commander": "^9.0.0",
+        "handlebars": "^4.7.7",
+        "json-schema-ref-parser": "^9.0.9"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
+          "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -23120,6 +23476,13 @@
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+      "dev": true,
+      "optional": true
+    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -23639,6 +24002,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "workbox-background-sync": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "5.5.2",
         "axios": "0.26.1",
         "form-data": "4.0.0",
+        "mobx-react-lite": "3.3.0",
         "prop-types": "15.8.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -8280,6 +8281,37 @@
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/mobx": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.5.0.tgz",
+      "integrity": "sha512-pHZ/cySF00FVENDWIDzJyoObFahK6Eg4d0papqm6d7yMkxWTZ/S/csqJX1A3PsYy4t5k3z2QnlwuCfMW5lSEwA==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.3.0.tgz",
+      "integrity": "sha512-U/kMSFtV/bNVgY01FuiGWpRkaQVHozBq5CEBZltFvPt4FcV111hEWkgwqVg9GPPZSEuEdV438PEz8mk8mKpYlA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.1.0",
+        "react": "^16.8.0 || ^17"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/ms": {
@@ -20429,6 +20461,18 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mobx": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.5.0.tgz",
+      "integrity": "sha512-pHZ/cySF00FVENDWIDzJyoObFahK6Eg4d0papqm6d7yMkxWTZ/S/csqJX1A3PsYy4t5k3z2QnlwuCfMW5lSEwA==",
+      "peer": true
+    },
+    "mobx-react-lite": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.3.0.tgz",
+      "integrity": "sha512-U/kMSFtV/bNVgY01FuiGWpRkaQVHozBq5CEBZltFvPt4FcV111hEWkgwqVg9GPPZSEuEdV438PEz8mk8mKpYlA==",
+      "requires": {}
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@mui/icons-material": "5.5.1",
     "@mui/material": "5.5.2",
     "axios": "0.26.1",
+    "form-data": "4.0.0",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -31,6 +32,7 @@
     "eslint": "8.12.0",
     "eslint-plugin-prettier": "4.0.0",
     "lint-staged": "12.3.6",
+    "openapi-typescript-codegen": "0.20.1",
     "prettier": "2.6.0",
     "react-scripts": "5.0.0",
     "typescript": "4.6.2"
@@ -40,7 +42,8 @@
     "build": "node_modules/react-scripts/bin/react-scripts.js build",
     "test": "node_modules/react-scripts/bin/react-scripts.js test",
     "lint": "node_modules/eslint/bin/eslint.js --fix .",
-    "lint-check": "node_modules/eslint/bin/eslint.js ."
+    "lint-check": "node_modules/eslint/bin/eslint.js .",
+    "openapi-generate": "node_modules/openapi-typescript-codegen/bin/index.js -c axios --name AppClient --input ./screw-your-neighbor-server-openapi.json --output ./src/generated"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@mui/material": "5.5.2",
     "axios": "0.26.1",
     "form-data": "4.0.0",
+    "mobx": "6.5.0",
+    "mobx-react-lite": "3.3.0",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/screw-your-neighbor-server-openapi.json
+++ b/screw-your-neighbor-server-openapi.json
@@ -1,0 +1,1638 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "https://screw-your-neighbor-server.herokuapp.com",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/games": {
+      "get": {
+        "tags": [
+          "game-entity-controller"
+        ],
+        "description": "get-game",
+        "operationId": "getCollectionResource-game-get_1",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Zero-based page index (0..N)",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "The size of the page to be returned",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedModelEntityModelGame"
+                }
+              },
+              "application/x-spring-data-compact+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedModelEntityModelGame"
+                }
+              },
+              "text/uri-list": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "game-entity-controller"
+        ],
+        "description": "create-game",
+        "operationId": "postCollectionResource-game-post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GameRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/games/{id}": {
+      "get": {
+        "tags": [
+          "game-entity-controller"
+        ],
+        "description": "get-game",
+        "operationId": "getItemResource-game-get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "game-entity-controller"
+        ],
+        "description": "patch-game",
+        "operationId": "patchItemResource-game-patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GameRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/games/{id}/nextGame": {
+      "get": {
+        "tags": [
+          "game-property-reference-controller"
+        ],
+        "description": "get-game-by-game-Id",
+        "operationId": "followPropertyReference-game-get_1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              },
+              "text/uri-list": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "game-property-reference-controller"
+        ],
+        "description": "patch-game-by-game-Id",
+        "operationId": "createPropertyReference-game-patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectionModelObject"
+              }
+            },
+            "application/x-spring-data-compact+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectionModelObject"
+              }
+            },
+            "text/uri-list": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/games/{id}/nextGame/{propertyId}": {
+      "get": {
+        "tags": [
+          "game-property-reference-controller"
+        ],
+        "description": "get-game-by-game-Id",
+        "operationId": "followPropertyReference-game-get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "propertyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/games/{id}/participations": {
+      "get": {
+        "tags": [
+          "game-property-reference-controller"
+        ],
+        "description": "get-participation-by-game-Id",
+        "operationId": "followPropertyReference-game-get_2_1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionModelParticipation"
+                }
+              },
+              "text/uri-list": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "game-property-reference-controller"
+        ],
+        "description": "patch-participation-by-game-Id",
+        "operationId": "createPropertyReference-game-patch_1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectionModelObject"
+              }
+            },
+            "application/x-spring-data-compact+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectionModelObject"
+              }
+            },
+            "text/uri-list": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionModelParticipation"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/games/{id}/participations/{propertyId}": {
+      "get": {
+        "tags": [
+          "game-property-reference-controller"
+        ],
+        "description": "get-participation-by-game-Id",
+        "operationId": "followPropertyReference-game-get_2",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "propertyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CollectionModelParticipation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/participations": {
+      "get": {
+        "tags": [
+          "participation-entity-controller"
+        ],
+        "description": "get-participation",
+        "operationId": "getCollectionResource-participation-get_1",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Zero-based page index (0..N)",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "The size of the page to be returned",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedModelEntityModelParticipation"
+                }
+              },
+              "application/x-spring-data-compact+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedModelEntityModelParticipation"
+                }
+              },
+              "text/uri-list": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "participation-entity-controller"
+        ],
+        "description": "create-participation",
+        "operationId": "postCollectionResource-participation-post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ParticipationRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelParticipation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/participations/{id}": {
+      "get": {
+        "tags": [
+          "participation-entity-controller"
+        ],
+        "description": "get-participation",
+        "operationId": "getItemResource-participation-get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelParticipation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "participation-entity-controller"
+        ],
+        "description": "patch-participation",
+        "operationId": "patchItemResource-participation-patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ParticipationRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelParticipation"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/participations/{id}/game": {
+      "get": {
+        "tags": [
+          "participation-property-reference-controller"
+        ],
+        "description": "get-game-by-participation-Id",
+        "operationId": "followPropertyReference-participation-get_1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              },
+              "text/uri-list": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "participation-property-reference-controller"
+        ],
+        "description": "patch-game-by-participation-Id",
+        "operationId": "createPropertyReference-participation-patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectionModelObject"
+              }
+            },
+            "application/x-spring-data-compact+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectionModelObject"
+              }
+            },
+            "text/uri-list": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/participations/{id}/game/{propertyId}": {
+      "get": {
+        "tags": [
+          "participation-property-reference-controller"
+        ],
+        "description": "get-game-by-participation-Id",
+        "operationId": "followPropertyReference-participation-get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "propertyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/participations/{id}/player": {
+      "get": {
+        "tags": [
+          "participation-property-reference-controller"
+        ],
+        "description": "get-player-by-participation-Id",
+        "operationId": "followPropertyReference-participation-get_2_1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelPlayer"
+                }
+              },
+              "text/uri-list": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "participation-property-reference-controller"
+        ],
+        "description": "patch-player-by-participation-Id",
+        "operationId": "createPropertyReference-participation-patch_1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectionModelObject"
+              }
+            },
+            "application/x-spring-data-compact+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CollectionModelObject"
+              }
+            },
+            "text/uri-list": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelPlayer"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/participations/{id}/player/{propertyId}": {
+      "get": {
+        "tags": [
+          "participation-property-reference-controller"
+        ],
+        "description": "get-player-by-participation-Id",
+        "operationId": "followPropertyReference-participation-get_2",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "propertyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelPlayer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/players": {
+      "get": {
+        "tags": [
+          "player-entity-controller"
+        ],
+        "description": "get-player",
+        "operationId": "getCollectionResource-player-get_1",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Zero-based page index (0..N)",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "The size of the page to be returned",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedModelEntityModelPlayer"
+                }
+              },
+              "application/x-spring-data-compact+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedModelEntityModelPlayer"
+                }
+              },
+              "text/uri-list": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "player-entity-controller"
+        ],
+        "description": "create-player",
+        "operationId": "postCollectionResource-player-post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlayerRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelPlayer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/players/search/findAllByName": {
+      "get": {
+        "tags": [
+          "player-search-controller"
+        ],
+        "operationId": "executeSearch-player-get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Zero-based page index (0..N)",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "The size of the page to be returned",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedModelEntityModelPlayer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/players/{id}": {
+      "get": {
+        "tags": [
+          "player-entity-controller"
+        ],
+        "description": "get-player",
+        "operationId": "getItemResource-player-get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelPlayer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "player-entity-controller"
+        ],
+        "description": "delete-player",
+        "operationId": "deleteItemResource-player-delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "player-entity-controller"
+        ],
+        "description": "patch-player",
+        "operationId": "patchItemResource-player-patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlayerRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityModelPlayer"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/profile": {
+      "get": {
+        "tags": [
+          "profile-controller"
+        ],
+        "operationId": "listAllFormsOfMetadata_1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepresentationModelObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/games": {
+      "get": {
+        "tags": [
+          "profile-controller"
+        ],
+        "operationId": "descriptor_1_1_1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/alps+json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/schema+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/participations": {
+      "get": {
+        "tags": [
+          "profile-controller"
+        ],
+        "operationId": "descriptor_1_1_2",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/alps+json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/schema+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profile/players": {
+      "get": {
+        "tags": [
+          "profile-controller"
+        ],
+        "operationId": "descriptor_1_1_3",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/alps+json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/schema+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "tags": [
+          "hello-world-controller"
+        ],
+        "operationId": "helloWorld",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HelloWorld"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AbstractJsonSchemaPropertyObject": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "readOnly": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Item": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AbstractJsonSchemaPropertyObject"
+            }
+          },
+          "requiredProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "JsonSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AbstractJsonSchemaPropertyObject"
+            }
+          },
+          "requiredProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "definitions": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Item"
+            }
+          },
+          "type": {
+            "type": "string"
+          },
+          "$schema": {
+            "type": "string"
+          }
+        }
+      },
+      "Links": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Link"
+        }
+      },
+      "RepresentationModelObject": {
+        "type": "object",
+        "properties": {
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          }
+        }
+      },
+      "EntityModelPlayer": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          }
+        }
+      },
+      "PageMetadata": {
+        "type": "object",
+        "properties": {
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "number": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PagedModelEntityModelPlayer": {
+        "type": "object",
+        "properties": {
+          "_embedded": {
+            "type": "object",
+            "properties": {
+              "players": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntityModelPlayer"
+                }
+              }
+            }
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          },
+          "page": {
+            "$ref": "#/components/schemas/PageMetadata"
+          }
+        }
+      },
+      "EntityModelGame": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "gameState": {
+            "type": "string",
+            "enum": [
+              "FINDING_PLAYERS",
+              "PLAYING",
+              "CLOSED"
+            ]
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          }
+        }
+      },
+      "PagedModelEntityModelGame": {
+        "type": "object",
+        "properties": {
+          "_embedded": {
+            "type": "object",
+            "properties": {
+              "games": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntityModelGame"
+                }
+              }
+            }
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          },
+          "page": {
+            "$ref": "#/components/schemas/PageMetadata"
+          }
+        }
+      },
+      "CollectionModelObject": {
+        "type": "object",
+        "properties": {
+          "_embedded": {
+            "type": "object",
+            "properties": {
+              "objects": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          }
+        }
+      },
+      "CollectionModelParticipation": {
+        "type": "object",
+        "properties": {
+          "_embedded": {
+            "type": "object",
+            "properties": {
+              "participations": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ParticipationResponse"
+                }
+              }
+            }
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          }
+        }
+      },
+      "EntityModelParticipation": {
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "participationNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          }
+        }
+      },
+      "PagedModelEntityModelParticipation": {
+        "type": "object",
+        "properties": {
+          "_embedded": {
+            "type": "object",
+            "properties": {
+              "participations": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntityModelParticipation"
+                }
+              }
+            }
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
+          },
+          "page": {
+            "$ref": "#/components/schemas/PageMetadata"
+          }
+        }
+      },
+      "GameRequestBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "gameState": {
+            "type": "string",
+            "enum": [
+              "FINDING_PLAYERS",
+              "PLAYING",
+              "CLOSED"
+            ]
+          },
+          "participations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "nextGame": {
+            "type": "string"
+          }
+        }
+      },
+      "ParticipationRequestBody": {
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "participationNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "game": {
+            "type": "string"
+          },
+          "player": {
+            "type": "string"
+          }
+        }
+      },
+      "PlayerRequestBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ParticipationResponse": {
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "participationNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "HelloWorld": {
+        "type": "object",
+        "properties": {
+          "hello": {
+            "type": "string"
+          }
+        }
+      },
+      "Link": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "hreflang": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "deprecation": {
+            "type": "string"
+          },
+          "profile": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "templated": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/screw-your-neighbor-server-openapi.json
+++ b/screw-your-neighbor-server-openapi.json
@@ -107,7 +107,7 @@
         }
       }
     },
-    "/games/{id}": {
+    "/games/{id}?projection=embed": {
       "get": {
         "tags": [
           "game-entity-controller"
@@ -545,7 +545,7 @@
         }
       }
     },
-    "/participations/{id}": {
+    "/participations/{id}?projection=embed": {
       "get": {
         "tags": [
           "participation-entity-controller"
@@ -1431,6 +1431,20 @@
               "CLOSED"
             ]
           },
+          "_embedded": {
+            "type": "object",
+            "properties": {
+              "participations": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntityModelParticipation"
+                }
+              }
+            }
+          },
+          "nextGame": {
+            "$ref": "#/components/schemas/EntityModelGame"
+          },
           "_links": {
             "$ref": "#/components/schemas/Links"
           }
@@ -1505,6 +1519,12 @@
           "participationNumber": {
             "type": "integer",
             "format": "int32"
+          },
+          "player" : {
+            "$ref": "#/components/schemas/EntityModelPlayer"
+          },
+          "game" : {
+            "$ref": "#/components/schemas/EntityModelGame"
           },
           "_links": {
             "$ref": "#/components/schemas/Links"
@@ -1593,6 +1613,12 @@
           "participationNumber": {
             "type": "integer",
             "format": "int32"
+          },
+          "player" : {
+            "$ref": "#/components/schemas/EntityModelPlayer"
+          },
+          "game" : {
+            "$ref": "#/components/schemas/EntityModelGame"
           }
         }
       },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,16 @@
 import React from "react"
 import "./styles/index.scss"
 import AppRouter from "./components/routing/routers/AppRouter"
+import { AppContextProvider } from "./AppContext"
+import { ApiErrorSnackBar } from "./components/ui/ApiErrorSnackBar"
 
 const App = () => {
   return (
     <div>
-      <AppRouter />
+      <AppContextProvider>
+        <ApiErrorSnackBar />
+        <AppRouter />
+      </AppContextProvider>
     </div>
   )
 }

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -1,0 +1,10 @@
+import React, { createContext } from "react"
+import { useLocalObservable } from "mobx-react-lite"
+import { AppStore } from "./stores/AppStore"
+
+export const appContext = createContext(new AppStore())
+
+export const AppContextProvider = ({ children }) => {
+  const appStore = useLocalObservable(() => new AppStore())
+  return <appContext.Provider value={appStore}>{children}</appContext.Provider>
+}

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,4 @@
-import axios from "axios"
+import { AppClient } from "../generated"
 
 const isProduction = process.env.NODE_ENV === "production"
 
@@ -9,9 +9,8 @@ const getDomain = () => {
   return isProduction ? prodUrl : devUrl
 }
 
-const api = axios.create({
-  baseURL: getDomain(),
-  headers: { "Content-Type": "application/json" },
+const api = new AppClient({
+  BASE: getDomain(),
 })
 
 const handleError = (error) => {
@@ -44,4 +43,5 @@ const handleError = (error) => {
     return error.message
   }
 }
+
 export { api, handleError }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -13,35 +13,4 @@ const api = new AppClient({
   BASE: getDomain(),
 })
 
-const handleError = (error) => {
-  const response = error.response
-
-  // catch 4xx and 5xx status codes
-  if (response && !!`${response.status}`.match(/^[4|5]\d{2}$/)) {
-    let info = `\nrequest to: ${response.request.responseURL}`
-
-    if (response.data.status) {
-      info += `\nstatus code: ${response.data.status}`
-      info += `\nerror: ${response.data.error}`
-      info += `\nerror message: ${response.data.message}`
-    } else {
-      info += `\nstatus code: ${response.status}`
-      info += `\nerror message:\n${response.data}`
-    }
-
-    console.log(
-      "The request was made and answered but was unsuccessful.",
-      error.response
-    )
-    return info
-  } else {
-    if (error.message.match(/Network Error/)) {
-      alert("The server cannot be reached.\nDid you start it?")
-    }
-
-    console.log("Something else happened.", error)
-    return error.message
-  }
-}
-
-export { api, handleError }
+export { api }

--- a/src/components/routing/routers/AppRouter.tsx
+++ b/src/components/routing/routers/AppRouter.tsx
@@ -5,6 +5,7 @@ import { LobbyGuard } from "../routeProtectors/LobbyGuard"
 import Register from "../../views/Register"
 import Lobby from "../../views/Lobby"
 import Sandbox from "../../views/Sandbox"
+import { Paths } from "./Paths"
 
 /**
  */
@@ -12,24 +13,27 @@ const AppRouter = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Navigate to="/register" />} />
         <Route
-          path="/lobby"
+          path={Paths.HOME}
+          element={<Navigate to={Paths.CREATE_PLAYER} />}
+        />
+        <Route
+          path={Paths.LOBBY}
           element={
             <LobbyGuard>
-              <Lobby base="/lobby" />
+              <Lobby />
             </LobbyGuard>
           }
         />
         <Route
-          path="/register"
+          path={Paths.CREATE_PLAYER}
           element={
             <RegisterGuard>
-              <Register base="/register" />
+              <Register />
             </RegisterGuard>
           }
         />
-        <Route path="/sandbox" element={<Sandbox />} />
+        <Route path={Paths.SANDBOX} element={<Sandbox />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/components/routing/routers/Paths.ts
+++ b/src/components/routing/routers/Paths.ts
@@ -1,0 +1,7 @@
+export enum Paths {
+  HOME = "/",
+  CREATE_PLAYER = "/createPlayer",
+  LOBBY = "/lobby",
+  GAME = "/game",
+  SANDBOX = "/sandbox",
+}

--- a/src/components/ui/ApiErrorSnackBar.tsx
+++ b/src/components/ui/ApiErrorSnackBar.tsx
@@ -1,0 +1,36 @@
+import React, { useContext } from "react"
+import { appContext } from "../../AppContext"
+import { Alert, IconButton, Snackbar } from "@mui/material"
+import { observer } from "mobx-react-lite"
+import CloseIcon from "@mui/icons-material/Close"
+
+export const ApiErrorSnackBar = observer(() => {
+  const appStore = useContext(appContext)
+  const errorMessage = appStore.errorMessage
+
+  const onClose = () => appStore.setErrorMessage(null)
+
+  return (
+    <Snackbar
+      open={!!errorMessage}
+      autoHideDuration={6000}
+      onClose={onClose}
+      anchorOrigin={{
+        horizontal: "center",
+        vertical: "top",
+      }}
+    >
+      <Alert severity={"error"}>
+        <span>{errorMessage}</span>
+        <IconButton
+          size="small"
+          aria-label="close"
+          color="inherit"
+          onClick={onClose}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Alert>
+    </Snackbar>
+  )
+})

--- a/src/components/views/Lobby.tsx
+++ b/src/components/views/Lobby.tsx
@@ -11,7 +11,7 @@ import "../../styles/ui/Divs.scss"
 import "../../styles/ui/Lists.scss"
 import "../../styles/ui/images.scss"
 
-const Lobby = observer((props) => {
+const Lobby = observer(() => {
   const navigate = useNavigate()
   const { startPollPlayers, players } = usePlayers()
 

--- a/src/components/views/Lobby.tsx
+++ b/src/components/views/Lobby.tsx
@@ -1,15 +1,24 @@
-import React from "react"
+import React, { useEffect } from "react"
+import { observer } from "mobx-react-lite"
 import Footer from "../ui/Footer"
 import BaseContainer from "../ui/BaseContainer"
 import { useNavigate } from "react-router-dom"
-import { handleError } from "../../api/api"
+import { usePlayers } from "../../hooks/api/usePlayers"
+import { Paths } from "../routing/routers/Paths"
+import { Grid } from "@mui/material"
 import "../../styles/ui/Button.scss"
 import "../../styles/ui/Divs.scss"
 import "../../styles/ui/Lists.scss"
 import "../../styles/ui/images.scss"
 
-const Lobby = (props) => {
+const Lobby = observer((props) => {
   const navigate = useNavigate()
+  const { startPollPlayers, players } = usePlayers()
+
+  useEffect(() => {
+    const playersSubscription = startPollPlayers()
+    return () => playersSubscription.cancel()
+  })
   /* code for later!
   const Room = ({room}) => (
         <div className="">
@@ -24,37 +33,11 @@ const Lobby = (props) => {
       localStorage.removeItem("id")
 
       // Register successfully worked --> navigate to the route /game in the GameRouter
-      navigate("/register")
+      navigate(Paths.CREATE_PLAYER)
       console.log("logged out")
     } catch (error) {
-      alert(`Something went wrong during the register: \n${handleError(error)}`)
       console.log(error)
     }
-  }
-
-  let content = (
-    <img
-      src="https://grrrls.at/wp-content/uploads/2020/01/no-image.jpg"
-      alt="Lamp"
-      width="32"
-      height="32"
-    ></img>
-  ) //placeholder
-  if (localStorage.getItem("id") != null) {
-    content = (
-      <div className="div-rooms">
-        <div className="roomlist">
-          <div className="roomlistitem">Room 1</div>
-          <div className="roomlistitem">Room 2</div>
-          <div className="roomlistitem">Room 3</div>
-          <div className="roomlistitem">Room 4</div>
-        </div>
-
-        <button className="button" onClick={() => doLogout()}>
-          Logout
-        </button>
-      </div>
-    )
   }
 
   return (
@@ -62,16 +45,40 @@ const Lobby = (props) => {
       <BaseContainer>
         <h1 className="font-title">Lobby</h1>
       </BaseContainer>
-      <br />
-      <BaseContainer>
-        <h3>Choose one of the Rooms to join</h3>
-        {content}
-      </BaseContainer>
+      <Grid container spacing={2}>
+        <Grid item xs={9}>
+          <BaseContainer>
+            <h3>Choose one of the Rooms to join</h3>
+            <div className="div-rooms">
+              <div className="roomlist">
+                <div className="roomlistitem">Room 1</div>
+                <div className="roomlistitem">Room 2</div>
+                <div className="roomlistitem">Room 3</div>
+                <div className="roomlistitem">Room 4</div>
+              </div>
+
+              <button className="button" onClick={() => doLogout()}>
+                Logout
+              </button>
+            </div>
+          </BaseContainer>
+        </Grid>
+        <Grid item xs={2}>
+          <BaseContainer>
+            <h3>Available players</h3>
+            <ul>
+              {players.map((value) => (
+                <li key={value._links.self.href}>{value.name}</li>
+              ))}
+            </ul>
+          </BaseContainer>
+        </Grid>
+      </Grid>
 
       <Footer />
       <div className="background-img"></div>
     </div>
   )
-}
+})
 
 export default Lobby

--- a/src/components/views/Register.tsx
+++ b/src/components/views/Register.tsx
@@ -1,9 +1,6 @@
 import React, { useEffect, useState } from "react"
 import { usePlayers } from "../../hooks/api/usePlayers"
-import React, { useState } from "react"
-import BaseContainer from "../ui/BaseContainer"
 import Footer from "../ui/Footer"
-import Player from "../../models/Player"
 import { useNavigate } from "react-router-dom"
 import { Paths } from "../routing/routers/Paths"
 

--- a/src/components/views/Register.tsx
+++ b/src/components/views/Register.tsx
@@ -1,11 +1,14 @@
+import React, { useEffect, useState } from "react"
+import { usePlayers } from "../../hooks/api/usePlayers"
 import React, { useState } from "react"
 import BaseContainer from "../ui/BaseContainer"
 import Footer from "../ui/Footer"
 import Player from "../../models/Player"
 import { useNavigate } from "react-router-dom"
-import { api, handleError } from "../../api/api"
+import { Paths } from "../routing/routers/Paths"
 
 import Button from "@mui/material/Button"
+import BaseContainer from "../ui/BaseContainer"
 import SendIcon from "@mui/icons-material/Send"
 import { TextField } from "@mui/material"
 import Box from "@mui/material/Box"
@@ -13,41 +16,25 @@ import "../../styles/fonts.scss"
 import "../../styles/ui/Box.scss"
 import "../../styles/ui/Divs.scss"
 import "../../styles/ui/images.scss"
-/**
- * Landing page where a user can be registered
- * @param props
- * @returns
- */
-const Register = (props) => {
-  // Get the existing path
+
+const Register = () => {
   const navigate = useNavigate()
   const [name, setName] = useState("")
-  // user for text field change to update the name
-  const handleChange = (e) => {
+  const changeName = (e) => {
     setName(e.target.value)
   }
 
-  /**
-   * Send the player registeration to the endpoint
-   */
-  const doRegister = async () => {
-    try {
-      const requestBody = JSON.stringify({ name })
-      const response = await api.post("/players", requestBody)
+  const { loading, createPlayer, startPollPlayers } = usePlayers()
 
-      // Get the returned user and update a new object.
-      const player = new Player(response.data)
-
-      // Store the token into the local storage.
-      localStorage.setItem("id", `${player.id}`)
-
-      // Register successfully worked --> navigate to the route /game in the GameRouter
-      navigate("/lobby")
-    } catch (error) {
-      alert(`Something went wrong during the register: \n${handleError(error)}`)
-      console.log(error)
-    }
+  const submit = async () => {
+    await createPlayer(name)
+    navigate(Paths.LOBBY)
   }
+
+  useEffect(() => {
+    const playersSubscription = startPollPlayers()
+    return () => playersSubscription.cancel()
+  })
 
   return (
     <div className="div-box">
@@ -67,13 +54,14 @@ const Register = (props) => {
             id="demo-helper-text-aligned"
             label="player name"
             value={name}
-            onChange={handleChange}
+            onChange={changeName}
           />
           <p></p>
           <Button
+            disabled={loading}
             variant="contained"
             endIcon={<SendIcon />}
-            onClick={() => doRegister()}
+            onClick={submit}
           >
             TAKE ME TO THE LOBBY
           </Button>

--- a/src/hooks/api/useApi.ts
+++ b/src/hooks/api/useApi.ts
@@ -1,0 +1,24 @@
+import { useContext } from "react"
+import { appContext } from "../../AppContext"
+import { api } from "../../api/api"
+import { ApiError } from "../../generated"
+
+export const useApi = () => {
+  const appStore = useContext(appContext)
+
+  const wrapApiCall = async <T>(apiCall: Promise<T>) => {
+    try {
+      return await apiCall
+    } catch (e) {
+      if (e instanceof ApiError) {
+        appStore.setErrorMessage(e.message)
+      }
+      throw e
+    }
+  }
+
+  return {
+    wrapApiCall,
+    ...api,
+  }
+}

--- a/src/hooks/api/usePlayers.ts
+++ b/src/hooks/api/usePlayers.ts
@@ -27,10 +27,12 @@ export function usePlayers() {
   }
 
   const startPollPlayers = () => {
-    playerStore.playersSubscription = setInterval(refreshPlayers, 500)
+    playerStore.playersSubscriptions.addSubscription(
+      setInterval(refreshPlayers, 500)
+    )
     return {
       cancel() {
-        playerStore.clearPlayerSubscription()
+        playerStore.playersSubscriptions.removeSubscription()
       },
     }
   }

--- a/src/hooks/api/usePlayers.ts
+++ b/src/hooks/api/usePlayers.ts
@@ -1,0 +1,45 @@
+import { useContext, useState } from "react"
+import { appContext } from "../../AppContext"
+import { useApi } from "./useApi"
+
+export function usePlayers() {
+  const playerStore = useContext(appContext).playerStore
+  const [loading, setLoading] = useState(false)
+
+  const { wrapApiCall, playerEntityController } = useApi()
+
+  const createPlayer = async (name) => {
+    setLoading(true)
+    const createdPlayer = await wrapApiCall(
+      playerEntityController.postCollectionResourcePlayerPost({
+        name,
+      })
+    ).finally(() => setLoading(false))
+    playerStore.setMe(createdPlayer)
+    return createdPlayer
+  }
+
+  const refreshPlayers = async () => {
+    const players = await wrapApiCall(
+      playerEntityController.getCollectionResourcePlayerGet1()
+    )
+    playerStore.setPlayers(players._embedded.players)
+  }
+
+  const startPollPlayers = () => {
+    playerStore.playersSubscription = setInterval(refreshPlayers, 500)
+    return {
+      cancel() {
+        playerStore.clearPlayerSubscription()
+      },
+    }
+  }
+
+  return {
+    loading,
+    me: playerStore.me,
+    players: playerStore.players,
+    startPollPlayers,
+    createPlayer,
+  }
+}

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1,0 +1,16 @@
+import { PlayerStore } from "./PlayerStore"
+import { action, makeAutoObservable, observable } from "mobx"
+
+export class AppStore {
+  @observable errorMessage?: string
+  readonly playerStore = new PlayerStore()
+
+  constructor() {
+    makeAutoObservable(this)
+  }
+
+  @action
+  setErrorMessage(value: string | null) {
+    this.errorMessage = value
+  }
+}

--- a/src/stores/PlayerStore.ts
+++ b/src/stores/PlayerStore.ts
@@ -1,0 +1,37 @@
+import { EntityModelPlayer } from "../generated"
+import { action, makeObservable, observable } from "mobx"
+
+export class PlayerStore {
+  @observable me: EntityModelPlayer
+  @observable players: Array<EntityModelPlayer>
+  private _playersSubscription?: NodeJS.Timer
+
+  constructor() {
+    this.me = null
+    this.players = []
+    makeObservable(this)
+  }
+
+  @action
+  setMe(player?: EntityModelPlayer) {
+    this.me = player
+  }
+
+  @action
+  setPlayers(players: Array<EntityModelPlayer>) {
+    this.players = players
+  }
+
+  set playersSubscription(value: NodeJS.Timer) {
+    if (this._playersSubscription) {
+      clearInterval(value)
+      return
+    }
+    this._playersSubscription = value
+  }
+
+  clearPlayerSubscription() {
+    clearInterval(this._playersSubscription)
+    this._playersSubscription = null
+  }
+}

--- a/src/stores/PlayerStore.ts
+++ b/src/stores/PlayerStore.ts
@@ -1,10 +1,11 @@
 import { EntityModelPlayer } from "../generated"
 import { action, makeObservable, observable } from "mobx"
+import { KeepOnlyOneInterval } from "../util/KeepOnlyOneInterval"
 
 export class PlayerStore {
   @observable me: EntityModelPlayer
   @observable players: Array<EntityModelPlayer>
-  private _playersSubscription?: NodeJS.Timer
+  private _playersSubscriptions = new KeepOnlyOneInterval()
 
   constructor() {
     this.me = null
@@ -22,16 +23,7 @@ export class PlayerStore {
     this.players = players
   }
 
-  set playersSubscription(value: NodeJS.Timer) {
-    if (this._playersSubscription) {
-      clearInterval(value)
-      return
-    }
-    this._playersSubscription = value
-  }
-
-  clearPlayerSubscription() {
-    clearInterval(this._playersSubscription)
-    this._playersSubscription = null
+  get playersSubscriptions(): KeepOnlyOneInterval {
+    return this._playersSubscriptions
   }
 }

--- a/src/styles/ui/BaseContainer.scss
+++ b/src/styles/ui/BaseContainer.scss
@@ -12,7 +12,6 @@
   padding-left: 5px;
   margin-right: auto;
   padding-right: 5px;
-  width: 750px;
   margin-top: 20px;
   max-width: $DESKTOP_WIDTH;
   color: $textColor;

--- a/src/util/KeepOnlyOneInterval.test.ts
+++ b/src/util/KeepOnlyOneInterval.test.ts
@@ -1,0 +1,61 @@
+import { KeepOnlyOneInterval } from "./KeepOnlyOneInterval"
+
+const INTERVAL = 100
+describe("KeepOnlyOneInterval", () => {
+  beforeEach(async () => {
+    jest.useFakeTimers()
+  })
+  afterEach(async () => {
+    jest.useRealTimers()
+  })
+  const setup = () => {
+    const fetchFunction = jest.fn()
+    const fetchFunction2 = jest.fn()
+    const keepOnlyOneInterval = new KeepOnlyOneInterval()
+    return {
+      keepOnlyOneInterval,
+      fetchFunction,
+      fetchFunction2,
+    }
+  }
+  it("keeps added timer and executes after interval", async () => {
+    const { keepOnlyOneInterval, fetchFunction } = setup()
+    keepOnlyOneInterval.addSubscription(setInterval(fetchFunction, INTERVAL))
+
+    jest.advanceTimersByTime(INTERVAL)
+    expect(fetchFunction).toBeCalled()
+
+    jest.advanceTimersByTime(INTERVAL)
+    expect(fetchFunction).toBeCalledTimes(2)
+  })
+
+  it("clears the second interval directly when added", async () => {
+    const { keepOnlyOneInterval, fetchFunction, fetchFunction2 } = setup()
+    keepOnlyOneInterval.addSubscription(setInterval(fetchFunction, INTERVAL))
+    keepOnlyOneInterval.addSubscription(setInterval(fetchFunction2, INTERVAL))
+
+    jest.advanceTimersByTime(INTERVAL)
+    expect(fetchFunction2).not.toBeCalled()
+
+    jest.advanceTimersByTime(INTERVAL)
+    expect(fetchFunction2).not.toBeCalled()
+  })
+
+  it("clears the interval when the last subscription is removed", async () => {
+    const { keepOnlyOneInterval, fetchFunction, fetchFunction2 } = setup()
+    keepOnlyOneInterval.addSubscription(setInterval(fetchFunction, INTERVAL))
+    keepOnlyOneInterval.addSubscription(setInterval(fetchFunction2, INTERVAL))
+    keepOnlyOneInterval.addSubscription(setInterval(fetchFunction2, INTERVAL))
+
+    keepOnlyOneInterval.removeSubscription()
+    keepOnlyOneInterval.removeSubscription()
+
+    jest.advanceTimersByTime(INTERVAL)
+    expect(fetchFunction).toBeCalled()
+
+    keepOnlyOneInterval.removeSubscription()
+
+    jest.advanceTimersByTime(INTERVAL)
+    expect(fetchFunction).toBeCalledTimes(1)
+  })
+})

--- a/src/util/KeepOnlyOneInterval.ts
+++ b/src/util/KeepOnlyOneInterval.ts
@@ -1,0 +1,21 @@
+export class KeepOnlyOneInterval {
+  private _subscriptions = 0
+  private _timer?: NodeJS.Timer
+
+  addSubscription(value: NodeJS.Timer) {
+    this._subscriptions++
+    if (this._subscriptions > 1) {
+      clearInterval(value)
+      return
+    }
+    this._timer = value
+  }
+
+  removeSubscription() {
+    this._subscriptions--
+    if (this._subscriptions === 0) {
+      clearInterval(this._timer)
+      this._timer = null
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
+    "moduleResolution": "node",
     "jsx": "react",
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "target": "ES2015"
   },
   "include": [
     "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "experimentalDecorators": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react",


### PR DESCRIPTION
This generates classes which handle creating the request, sending the request, parsing the response etc for us.
Plus we have all the domain classes generated and guaranteed equal to the definitions in the backend.

Showcase of embedded entities is here: https://github.com/sopra-fs22-group-36/screw-your-neighbor-react/commit/257c50a72e512a291d87dc8ea434181a69c83db5

Needs https://github.com/sopra-fs22-group-36/screw-your-neighbor-server/pull/74 to work.
(Else the CORS configuraiton for /games/ is not available)

Issue: https://github.com/sopra-fs22-group-36/screw-your-neighbor-server/issues/43