### PR TITLE
Feature fix heroku build

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,8 +7,18 @@ on:
 jobs:
   lint:
     name: "Lint"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, windows-2022 ]
+      fail-fast: false
     steps:
+      - name: "configure windows to use git correctly"
+        if: runner.os == 'Windows'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
 
       - uses: actions/setup-node@v2
@@ -24,14 +34,25 @@ jobs:
 
       - run: npm ci
 
+      - run: npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"
+        if: runner.os == 'Windows'
+
       - run: npm run openapi-generate
 
       - run: npm run lint-check
 
   unit-tests:
     name: "Unit tests"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, windows-2022 ]
     steps:
+      - name: "configure windows to use git correctly"
+        if: runner.os == 'Windows'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - uses: actions/checkout@v3
 
@@ -47,6 +68,9 @@ jobs:
             ${{ runner.os }}-node-
 
       - run: npm ci
+
+      - run: npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"
+        if: runner.os == 'Windows'
 
       - run: npm run openapi-generate
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "scripts": {
     "start": "node_modules/react-scripts/bin/react-scripts.js start",
-    "build": "node_modules/react-scripts/bin/react-scripts.js build",
+    "build": "npm run openapi-generate && npm run build-react",
+    "build-react": "node_modules/react-scripts/bin/react-scripts.js build",
     "test": "node_modules/react-scripts/bin/react-scripts.js test",
     "lint": "node_modules/eslint/bin/eslint.js --fix .",
     "lint-check": "node_modules/eslint/bin/eslint.js .",


### PR DESCRIPTION
package.json: generate openapi classes before building

Because heroku does not do that yet, it's a quick fix until we can tell heroku how to build.

Issue: https://github.com/sopra-fs22-group-36/screw-your-neighbor-server/issues/85

Also check if our package.json is windows compatible.