### PR TITLE
Feature offer calculated properties from store

### DIFF
--- a/src/components/routing/guards/GameGuard.tsx
+++ b/src/components/routing/guards/GameGuard.tsx
@@ -3,8 +3,8 @@ import { observer } from "mobx-react-lite"
 import { useNavigate } from "react-router-dom"
 import { useCurrentGame } from "../../../hooks/api/useCurrentGame"
 import { Paths } from "../routers/Paths"
-import { toIri } from "../../../util/toIri"
-import { ApiError, EntityModelGame, Game } from "../../../generated"
+import { ApiError, Game } from "../../../generated"
+import { iriMatch } from "../../../util/iriMatch"
 import { Loading } from "../../ui/Loading"
 import { delay } from "../../../util/timeout"
 import { Room } from "../../views/game/room/Room"
@@ -20,19 +20,11 @@ export type GameGuardProps = {
   redirectTo: Paths
 }
 
-function iriMatch(currentGameIriFromParameter: string, game: EntityModelGame) {
-  const iriWithOutEmbed = toIri(game._links.self)
-  const iriWithEmbed = iriWithOutEmbed + "?projection=embed"
-  return (
-    currentGameIriFromParameter === iriWithOutEmbed ||
-    currentGameIriFromParameter === iriWithEmbed
-  )
-}
-
 export const GameGuard = observer((props: GameGuardProps) => {
   const navigate = useNavigate()
   const { game, refreshGame, currentGameIriFromParameter } = useCurrentGame()
-  const gameReady = game && iriMatch(currentGameIriFromParameter, game)
+  const gameReady =
+    game && iriMatch(currentGameIriFromParameter, game._links.self)
 
   const [gameLoaded, setGameLoaded] = useState(gameReady)
 

--- a/src/components/views/game/game/gametable/GameTable.tsx
+++ b/src/components/views/game/game/gametable/GameTable.tsx
@@ -13,9 +13,9 @@ function createParticipation(name) {
 }
 
 export const GameTable = () => {
-  const { game } = useCurrentGame()
+  const { activeRound } = useCurrentGame()
 
-  const cards = game?.matches[0]?.rounds[0].cards || []
+  const cards = activeRound.cards || []
 
   const participationTwo = createParticipation("Player2")
   const participationThree = createParticipation("Player3")

--- a/src/components/views/game/game/scoreannouncing/ScoreAnnouncing.tsx
+++ b/src/components/views/game/game/scoreannouncing/ScoreAnnouncing.tsx
@@ -7,8 +7,8 @@ import insertCoin from "../../../../../img/icons/insert-coin.png"
 import CampaignOutlinedIcon from "@mui/icons-material/CampaignOutlined"
 
 export const ScoreAnnouncing = () => {
-  const { loading, announceScore } = useCurrentGame()
-  const [score, setScore] = useState(null)
+  const { loading, announceScore, yourActiveHand } = useCurrentGame()
+  const [score, setScore] = useState(yourActiveHand?.announcedScore)
 
   const clickAnnounceScore = async () => {
     await announceScore(score)

--- a/src/components/views/game/game/scoreannouncing/ScoreAnnouncing.tsx
+++ b/src/components/views/game/game/scoreannouncing/ScoreAnnouncing.tsx
@@ -14,6 +14,7 @@ export const ScoreAnnouncing = () => {
     await announceScore(score)
   }
 
+  const scoreAvailable = score !== null && score !== undefined
   return (
     <Box
       className={"score-announcing"}
@@ -57,12 +58,12 @@ export const ScoreAnnouncing = () => {
             InputLabelProps={{
               shrink: true,
             }}
-            value={score !== null ? score : null}
+            value={scoreAvailable ? score : ""}
             inputProps={{
               min: 0,
             }}
             onChange={(event) => {
-              setScore(event.target.value)
+              setScore(parseInt(event.target.value))
             }}
           />
         </Box>

--- a/src/components/views/game/game/yourhand/YourHand.tsx
+++ b/src/components/views/game/game/yourhand/YourHand.tsx
@@ -1,18 +1,16 @@
 import React, { useState } from "react"
 import { useCards } from "../../../../../hooks/api/useCards"
-import "./YourHand.scss"
-import { EntityModelCard } from "../../../../../generated"
 import { useCurrentGame } from "../../../../../hooks/api/useCurrentGame"
 import { CardComponent } from "../../../../ui/CardComponent"
+import "./YourHand.scss"
 
 export const YourHand = () => {
   const { updatecards } = useCards()
-  const { game } = useCurrentGame()
+  const { activeMatch, yourActiveHand } = useCurrentGame()
   const [opacity, setOpacity] = useState(10)
 
-  const match = game.matches[0]
-  const cards: Array<EntityModelCard> = match?.hands[0]?.cards || []
-  const notYetPlayed = cards.filter((value) => value.round === null)
+  const notYetPlayed =
+    yourActiveHand?.cards.filter((value) => value.round === null) ?? []
 
   const clickCard = async (card, number) => {
     setOpacity(number)
@@ -21,7 +19,7 @@ export const YourHand = () => {
 
   return (
     <div className="your-hand">
-      <p>These are the Cards for Match {match?.matchNumber}:</p>
+      <p>These are the Cards for Match {activeMatch?.matchNumber}:</p>
       {notYetPlayed.map((card, index) => (
         <div
           style={{

--- a/src/stores/CurrentGameStore.test.ts
+++ b/src/stores/CurrentGameStore.test.ts
@@ -1,0 +1,88 @@
+import { CurrentGameStore } from "./CurrentGameStore"
+
+const game = {
+  name: "game",
+  _embedded: {
+    matches: [
+      {
+        matchNumber: 2,
+      },
+      {
+        matchNumber: 1,
+      },
+    ],
+  },
+}
+
+const notEmbedded = {
+  name: "game",
+  matches: [
+    {
+      matchNumber: 2,
+    },
+    {
+      matchNumber: 1,
+    },
+  ],
+}
+
+const noMatches = {
+  name: "game",
+  _embedded: {
+    matches: [],
+  },
+}
+
+describe("The CurrentGameStore", () => {
+  describe("with the method sortedMatches", () => {
+    it("does not fail if no game present", () => {
+      const currentGameStore = new CurrentGameStore()
+
+      expect(currentGameStore.sortedMatches).toStrictEqual([])
+    })
+
+    it("sorts the matches by matchNumber", () => {
+      const currentGameStore = new CurrentGameStore()
+      currentGameStore.setGame(game)
+
+      expect(currentGameStore.sortedMatches).toStrictEqual([
+        game._embedded.matches[1],
+        game._embedded.matches[0],
+      ])
+    })
+
+    it("sorts the matches by matchNumber if not embedded", () => {
+      const currentGameStore = new CurrentGameStore()
+      currentGameStore.setGame(notEmbedded)
+
+      expect(currentGameStore.sortedMatches).toStrictEqual([
+        game._embedded.matches[1],
+        game._embedded.matches[0],
+      ])
+    })
+  })
+
+  describe("with the method activeMatch", () => {
+    it("does not fail if no game present", () => {
+      const currentGameStore = new CurrentGameStore()
+
+      expect(currentGameStore.activeMatch).toBeNull()
+    })
+
+    it("does not fail if no matches", () => {
+      const currentGameStore = new CurrentGameStore()
+      currentGameStore.setGame(noMatches)
+
+      expect(currentGameStore.activeMatch).toBeNull()
+    })
+
+    it("return the active match", () => {
+      const currentGameStore = new CurrentGameStore()
+      currentGameStore.setGame(game)
+
+      expect(currentGameStore.activeMatch).toStrictEqual(
+        game._embedded.matches[0]
+      )
+    })
+  })
+})

--- a/src/stores/CurrentGameStore.ts
+++ b/src/stores/CurrentGameStore.ts
@@ -1,4 +1,4 @@
-import { action, computed, makeAutoObservable, observable, toJS } from "mobx"
+import { action, computed, makeAutoObservable, observable } from "mobx"
 import { EntityModelGame, EntityModelParticipation } from "../generated"
 import { KeepOnlyOneInterval } from "../util/KeepOnlyOneInterval"
 import { embedProxy } from "../util/embedProxy"
@@ -23,13 +23,63 @@ export class CurrentGameStore {
   }
 
   @computed get activeParticipations() {
-    const entityModelGame = toJS(this.game)
-    if (!entityModelGame) {
+    if (!this.game) {
       return []
     }
     const entityModelEmbeddedHidden = embedProxy(this.game)
     return entityModelEmbeddedHidden.participations
       .filter((participation) => participation.active)
       .map(embedProxy)
+  }
+
+  @computed get sortedMatches() {
+    if (!this.game) {
+      return []
+    }
+
+    return (
+      embedProxy(this.game)
+        .matches?.slice()
+        .sort((a, b) => a.matchNumber - b.matchNumber) ?? []
+    )
+  }
+
+  @computed get activeMatch() {
+    if (this.sortedMatches.length === 0) {
+      return null
+    }
+    return this.sortedMatches.slice(-1)[0]
+  }
+
+  @computed get sortedRoundsOfActiveMatch() {
+    if (!this.activeMatch) {
+      return []
+    }
+    return this.activeMatch.rounds
+      .slice()
+      .sort((a, b) => a.roundNumber - b.roundNumber)
+  }
+
+  @computed get activeRound() {
+    if (this.sortedRoundsOfActiveMatch.length === 0) {
+      return null
+    }
+    return this.sortedRoundsOfActiveMatch.slice(-1)[0]
+  }
+
+  @computed get yourActiveHand() {
+    if (!this.participation) {
+      return null
+    }
+    const yourHands =
+      this.activeMatch?.hands.filter(
+        (value) =>
+          value.participation._links.self.href ===
+          this.participation._links.self.href
+      ) ?? []
+    if (yourHands.length === 0) {
+      return null
+    }
+    return yourHands.slice(-1)[0]
   }
 }

--- a/src/util/iriMatch.ts
+++ b/src/util/iriMatch.ts
@@ -1,0 +1,18 @@
+import { Link } from "../generated"
+import { toIri } from "./toIri"
+
+function toLink(iriOrString: string | Link): Link {
+  if (typeof iriOrString === "string") {
+    return {
+      href: iriOrString,
+    }
+  }
+  return iriOrString
+}
+
+export function iriMatch(iri1: string | Link, iri2: string | Link) {
+  const link1 = toIri(toLink(iri1)).replace("?projection=embed", "")
+  const link2 = toIri(toLink(iri2)).replace("?projection=embed", "")
+
+  return link1 === link2
+}


### PR DESCRIPTION
CurrentGameStore: add some helper computed methods

Use @computed methods, because they are reactive and get cached
if the source values don't change.

Add helper methods for:
- the matches sorted by matchNumber
- the active match
- the rounds of the active match sorted by roundNumber
- the active Round
- your hand

And use the methods.
Also add the correct participation to the store when refreshing the game.
Patch the correct hand in accounceScore.
Display the announced Score from the api in ScoreAnnouncing.tsx.
Now two players can start a game und play their cards, and see
what the other player played.

Issue: https://github.com/sopra-fs22-group-36/screw-your-neighbor-server/issues/59


ScoreAnnouncing: fix error that an input field should not get the value null

React prefers an empty string.

Issue: https://github.com/sopra-fs22-group-36/screw-your-neighbor-server/issues/64
