### PR TITLE
App.tsx: replace ugly browser scrollbar with darkScrollBar() from mui

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,16 @@ import AppRouter from "./components/routing/routers/AppRouter"
 import { AppContextProvider } from "./AppContext"
 import { ApiErrorSnackBar } from "./components/ui/ApiErrorSnackBar"
 import { HttpsGuard } from "./components/routing/guards/HttpsGuard"
+import { darkScrollbar, GlobalStyles } from "@mui/material"
 
 const App = () => {
   return (
     <div>
+      <GlobalStyles
+        styles={{
+          ...darkScrollbar(),
+        }}
+      />
       <HttpsGuard>
         <AppContextProvider>
           <ApiErrorSnackBar />


### PR DESCRIPTION
On Firefox it only appears when scrolling.
In Chrome:

![Screenshot from 2022-05-26 16-20-32](https://user-images.githubusercontent.com/1506818/170509387-43fb3511-85f0-4b17-abbd-f6b8e741fbb8.png)

